### PR TITLE
Implement glyph cache

### DIFF
--- a/lib/TextView/CMakeLists.txt
+++ b/lib/TextView/CMakeLists.txt
@@ -5,10 +5,12 @@ qt_add_library(TextViewLib
     FontLoader.h
     TextView.h
     TextFrameBuffer.h
+    DFCache.h
     DFGlyph.h
     FontLoader.cpp
     TextView.cpp
     TextFrameBuffer.cpp
+    DFCache.cpp
     DFGlyph.cpp
     TextAttributes.cpp
     TextAttributes.h

--- a/lib/TextView/DFCache.cpp
+++ b/lib/TextView/DFCache.cpp
@@ -1,0 +1,79 @@
+#include "DFCache.h"
+#include "FontLoader.h"
+#include <QRhi>
+#include <QDebug>
+#include <QImage>
+
+DFCache::DFCache(int cellsPerAtlas)
+    : m_cellsPerAtlas(cellsPerAtlas)
+{
+}
+
+DFCache::~DFCache()
+{
+    for (auto &a : m_atlases) {
+        if (a.texture)
+            a.texture->release();
+    }
+}
+
+DFCache::GlyphIndices DFCache::glyph(FontLoader *font,
+                                     QChar ch,
+                                     QRhi *rhi,
+                                     QRhiResourceUpdateBatch *updates)
+{
+    Key key{font, ch.unicode()};
+    {
+        QReadLocker rl(&m_lock);
+        auto it = m_cache.constFind(key);
+        if (it != m_cache.cend())
+            return it.value();
+    }
+
+    QWriteLocker wl(&m_lock);
+    auto it = m_cache.constFind(key);
+    if (it != m_cache.cend())
+        return it.value();
+    return addGlyph(key, font, ch, rhi, updates);
+}
+
+DFCache::GlyphIndices DFCache::addGlyph(const Key &key,
+                                        FontLoader *font,
+                                        QChar ch,
+                                        QRhi *rhi,
+                                        QRhiResourceUpdateBatch *updates)
+{
+    Q_ASSERT(rhi);
+    Q_ASSERT(updates);
+
+    QDistanceField df;
+    const QRawFont &f = font->font();
+    int idx = font->glyphIndex(ch);
+    df.setGlyph(f, idx, true);
+    QImage img = df.toImage(QImage::Format_Grayscale8);
+
+    if (m_atlases.isEmpty() || m_atlases.last().next >= m_cellsPerAtlas) {
+        Atlas a;
+        QSize size(img.width() * m_cellsPerAtlas, img.height());
+        a.texture = rhi->newTexture(QRhiTexture::R8, size, 1,
+                                    QRhiTexture::UsedAsTransferDst | QRhiTexture::UsedAsSampled);
+        if (!a.texture->create()) {
+            qWarning() << "Failed to create atlas texture";
+        }
+        m_atlases.append(a);
+    }
+
+    Atlas &atlas = m_atlases.last();
+    int indexInAtlas = atlas.next++;
+    QPoint pos(img.width() * indexInAtlas, 0);
+    QRhiTextureSubresourceUploadDescription subDesc(img);
+    subDesc.setDestinationTopLeft(pos);
+    QRhiTextureUploadEntry entry(0, 0, subDesc);
+    QRhiTextureUploadDescription desc(entry);
+    updates->uploadTexture(atlas.texture, desc);
+
+    GlyphIndices gi{m_atlases.size() - 1, indexInAtlas};
+    m_cache.insert(key, gi);
+    return gi;
+}
+

--- a/lib/TextView/DFCache.h
+++ b/lib/TextView/DFCache.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <QHash>
+#include <QReadWriteLock>
+#include <QRhiTexture>
+#include <QVector>
+#include <private/qdistancefield_p.h>
+
+class FontLoader;
+class QRhi;
+class QRhiResourceUpdateBatch;
+
+/*!\brief Glyph cache for distance field textures.
+ */
+class DFCache
+{
+public:
+    struct GlyphIndices {
+        int atlas = -1;  //!< index of the atlas texture
+        int index = -1;  //!< index of the glyph within the atlas
+    };
+
+    explicit DFCache(int cellsPerAtlas = 256);
+    ~DFCache();
+
+    GlyphIndices glyph(FontLoader *font,
+                       QChar ch,
+                       QRhi *rhi,
+                       QRhiResourceUpdateBatch *updates);
+
+private:
+    struct Key {
+        FontLoader *font;
+        char16_t ch;
+    };
+    struct KeyHash {
+        size_t operator()(const Key &k) const noexcept {
+            return qHash(quintptr(k.font)) ^ qHash(static_cast<quint32>(k.ch));
+        }
+    };
+    struct KeyEq {
+        bool operator()(const Key &a, const Key &b) const noexcept {
+            return a.font == b.font && a.ch == b.ch;
+        }
+    };
+
+    struct Atlas {
+        QRhiTexture *texture = nullptr;
+        int next = 0;
+    };
+
+    GlyphIndices addGlyph(const Key &key,
+                          FontLoader *font,
+                          QChar ch,
+                          QRhi *rhi,
+                          QRhiResourceUpdateBatch *updates);
+
+    const int m_cellsPerAtlas;
+    QReadWriteLock m_lock;
+    QHash<Key, GlyphIndices, KeyHash, KeyEq> m_cache;
+    QVector<Atlas> m_atlases;
+};
+


### PR DESCRIPTION
## Summary
- add DFCache for storing distance-field glyph textures
- register DFCache in the build
- use a grayscale QRhiTexture instead of RGBA

