### PR TITLE
Add QML-friendly framebuffer class

### DIFF
--- a/lib/TextView/CMakeLists.txt
+++ b/lib/TextView/CMakeLists.txt
@@ -4,12 +4,12 @@ qt_add_library(TextViewLib
     SHARED
     FontLoader.h
     TextView.h
-    TextFrameBuffer.h
+    TextFramebuffer.h
     DFCache.h
     DFGlyph.h
     FontLoader.cpp
     TextView.cpp
-    TextFrameBuffer.cpp
+    TextFramebuffer.cpp
     DFCache.cpp
     DFGlyph.cpp
     TextAttributes.cpp

--- a/lib/TextView/TextFramebuffer.h
+++ b/lib/TextView/TextFramebuffer.h
@@ -6,6 +6,8 @@
 #include <QChar>
 #include <QPoint>
 #include <QString>
+#include <QObject>
+#include <QtQml/qqml.h>
 
 #include "TextAttributes.h"
 
@@ -17,6 +19,7 @@ struct TextElement
 
 class TextBlock
 {
+    Q_GADGET
 public:
     TextBlock(int position = 0);
 
@@ -35,6 +38,7 @@ private:
 
 class TextLine
 {
+    Q_GADGET
 public:
     void addBlock(const TextBlock &block);
     void clear();
@@ -60,10 +64,12 @@ struct RenderCell
     TextAttributes attributes;
 };
 
-class TextFrameBuffer
+class TextFramebuffer : public QObject
 {
+    Q_OBJECT
+    QML_ELEMENT
 public:
-    TextFrameBuffer();
+    explicit TextFramebuffer(QObject *parent = nullptr);
 
     void putText(int row, int column, const QString &text, const TextAttributes &attr);
     void writeLn(const QString &text, const TextAttributes &attr);
@@ -74,6 +80,11 @@ public:
 
     const QVector<TextLine> &lines() const;
     QVector<TextLine> &lines();
+
+signals:
+    void changed(int pos, int count);
+    void linesAdded(int pos, int count);
+    void linesRemoved(int pos, int count);
 
 private:
     QVector<TextLine> m_lines;

--- a/lib/TextView/TextView.cpp
+++ b/lib/TextView/TextView.cpp
@@ -5,6 +5,84 @@ TextView::TextView(QQuickItem *parent)
 {
 }
 
+TextFramebuffer *TextView::framebuffer() const
+{
+    return m_framebuffer;
+}
+
+void TextView::setFramebuffer(TextFramebuffer *fb)
+{
+    if (m_framebuffer == fb)
+        return;
+    m_framebuffer = fb;
+    emit framebufferChanged();
+}
+
+int TextView::width() const
+{
+    return m_width;
+}
+
+void TextView::setWidth(int w)
+{
+    if (m_width == w)
+        return;
+    m_width = w;
+    emit widthChanged();
+}
+
+int TextView::height() const
+{
+    return m_height;
+}
+
+void TextView::setHeight(int h)
+{
+    if (m_height == h)
+        return;
+    m_height = h;
+    emit heightChanged();
+}
+
+int TextView::posX() const
+{
+    return m_posX;
+}
+
+void TextView::setPosX(int x)
+{
+    if (m_posX == x)
+        return;
+    m_posX = x;
+    emit posXChanged();
+}
+
+int TextView::posY() const
+{
+    return m_posY;
+}
+
+void TextView::setPosY(int y)
+{
+    if (m_posY == y)
+        return;
+    m_posY = y;
+    emit posYChanged();
+}
+
+QSizeF TextView::characterSize() const
+{
+    return m_characterSize;
+}
+
+void TextView::setCharacterSize(const QSizeF &size)
+{
+    if (m_characterSize == size)
+        return;
+    m_characterSize = size;
+    emit characterSizeChanged();
+}
+
 QQuickRhiItemRenderer *TextView::createRenderer()
 {
     return nullptr;

--- a/lib/TextView/TextView.h
+++ b/lib/TextView/TextView.h
@@ -2,14 +2,56 @@
 
 #include <QQuickRhiItem>
 #include <QtQml/qqml.h>
+#include <QSizeF>
+#include "TextFramebuffer.h"
 
 class TextView : public QQuickRhiItem
 {
     Q_OBJECT
     QML_ELEMENT
+    Q_PROPERTY(TextFramebuffer* framebuffer READ framebuffer WRITE setFramebuffer NOTIFY framebufferChanged)
+    Q_PROPERTY(int width READ width WRITE setWidth NOTIFY widthChanged)
+    Q_PROPERTY(int height READ height WRITE setHeight NOTIFY heightChanged)
+    Q_PROPERTY(int posX READ posX WRITE setPosX NOTIFY posXChanged)
+    Q_PROPERTY(int posY READ posY WRITE setPosY NOTIFY posYChanged)
+    Q_PROPERTY(QSizeF characterSize READ characterSize WRITE setCharacterSize NOTIFY characterSizeChanged)
 public:
     explicit TextView(QQuickItem *parent = nullptr);
 
+    TextFramebuffer *framebuffer() const;
+    void setFramebuffer(TextFramebuffer *fb);
+
+    int width() const;
+    void setWidth(int w);
+
+    int height() const;
+    void setHeight(int h);
+
+    int posX() const;
+    void setPosX(int x);
+
+    int posY() const;
+    void setPosY(int y);
+
+    QSizeF characterSize() const;
+    void setCharacterSize(const QSizeF &size);
+
+signals:
+    void framebufferChanged();
+    void widthChanged();
+    void heightChanged();
+    void posXChanged();
+    void posYChanged();
+    void characterSizeChanged();
+
 protected:
     QQuickRhiItemRenderer *createRenderer() override;
+
+private:
+    TextFramebuffer *m_framebuffer = nullptr;
+    int m_width = 0;
+    int m_height = 0;
+    int m_posX = 0;
+    int m_posY = 0;
+    QSizeF m_characterSize;
 };

--- a/test/text_buffer_test.cpp
+++ b/test/text_buffer_test.cpp
@@ -1,5 +1,5 @@
 #include <gtest/gtest.h>
-#include "TextFrameBuffer.h"
+#include "TextFramebuffer.h"
 
 TEST(TextLineTest, UpdatesBounds) {
     TextLine line;
@@ -34,8 +34,8 @@ TEST(TextLineTest, UpdatesBounds) {
     EXPECT_TRUE(line.blocks().isEmpty());
 }
 
-TEST(TextFrameBufferTest, FillClearPutTextCollect) {
-    TextFrameBuffer fb;
+TEST(TextFramebufferTest, FillClearPutTextCollect) {
+    TextFramebuffer fb;
     TextAttributes attr(QColor(), QColor(), QColor(), 0.0f, nullptr);
 
     fb.fill(QRect(0, 0, 3, 1), QChar('x'), attr);


### PR DESCRIPTION
## Summary
- rename TextFrameBuffer to TextFramebuffer
- emit signals when framebuffer data changes
- expose framebuffer and geometry via TextView QML properties
- update tests and build files

