### PR TITLE
Add TextView demo and QML API updates

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -3,3 +3,5 @@ add_executable(GLPainterApp main.cpp)
 target_link_libraries(GLPainterApp PRIVATE Qt6::Core)
 
 install(TARGETS GLPainterApp RUNTIME DESTINATION bin)
+
+add_subdirectory(TextViewDemoApp)

--- a/apps/TextViewDemoApp/CMakeLists.txt
+++ b/apps/TextViewDemoApp/CMakeLists.txt
@@ -1,0 +1,15 @@
+qt_add_executable(TextViewDemoApp
+    main.cpp
+)
+
+find_package(Qt6 REQUIRED COMPONENTS Quick Qml)
+
+qt_add_qml_module(TextViewDemoApp
+    URI TextViewDemoApp
+    VERSION 1.0
+    QML_FILES main.qml
+)
+
+target_link_libraries(TextViewDemoApp PRIVATE Qt6::Quick TextViewPlugin)
+
+install(TARGETS TextViewDemoApp RUNTIME DESTINATION bin)

--- a/apps/TextViewDemoApp/main.cpp
+++ b/apps/TextViewDemoApp/main.cpp
@@ -1,0 +1,16 @@
+#include <QGuiApplication>
+#include <QQmlApplicationEngine>
+
+int main(int argc, char **argv)
+{
+    QGuiApplication app(argc, argv);
+    QQmlApplicationEngine engine;
+    const QUrl url(QStringLiteral("qrc:/main.qml"));
+    QObject::connect(&engine, &QQmlApplicationEngine::objectCreated, &app,
+                     [url](QObject *obj, const QUrl &objUrl) {
+                         if (!obj && url == objUrl)
+                             QCoreApplication::exit(-1);
+                     }, Qt::QueuedConnection);
+    engine.load(url);
+    return app.exec();
+}

--- a/apps/TextViewDemoApp/main.qml
+++ b/apps/TextViewDemoApp/main.qml
@@ -1,0 +1,29 @@
+import QtQuick
+import UI.Editors
+
+Window {
+    id: root
+    width: 800
+    height: 600
+    visible: true
+
+    TextView {
+        anchors.fill: parent
+        renderWidth: 80
+        renderHeight: 60
+        framebuffer: _doc
+    }
+
+    TextFramebuffer {
+        id: _doc
+    }
+
+    Component.onCompleted: {
+        let attr = TextAttributes.create();
+        attr.color = Qt.rgba(255, 255, 255, 255);
+        attr.background = Qt.rgba(0, 0, 0, 0);
+        attr.outlineColor = Qt.rgba(255, 0, 0, 255);
+        attr.outlineWidth = 2.0;
+        _doc.putText(0, 0, "HelloWorld", attr);
+    }
+}

--- a/lib/TextView/CMakeLists.txt
+++ b/lib/TextView/CMakeLists.txt
@@ -69,6 +69,9 @@ qt_add_qml_module(TextViewPlugin
         plugin/FontLoaderObject.h
         plugin/TextFramebufferObject.cpp
         plugin/TextFramebufferObject.h
+        plugin/QmlTextAttributes.cpp
+        plugin/QmlTextAttributes.h
+        plugin/TextAttributesSingleton.h
 )
 
 target_link_libraries(TextViewPlugin

--- a/lib/TextView/lib/FontLoader.cpp
+++ b/lib/TextView/lib/FontLoader.cpp
@@ -2,6 +2,8 @@
 #include <QDebug>
 #include <cmath>
 
+namespace ui::textview {
+
 FontLoader::FontLoader(qreal pixelSize, int cellsPerAtlas)
     : m_pixelSize(pixelSize)
     , m_cellsPerAtlas(cellsPerAtlas)
@@ -34,6 +36,13 @@ bool FontLoader::loadFont(const QString &fileName)
         qWarning() << "Failed to load font" << fileName;
         return false;
     }
+}
+
+bool FontLoader::setFont(const QFont &font)
+{
+    m_font = QRawFont::fromFont(font, QFont::PreferDefaultHinting);
+    m_pixelSize = font.pixelSize();
+    return m_font.isValid();
 }
 
 bool FontLoader::isValid() const
@@ -144,3 +153,5 @@ QRhiTexture *FontLoader::atlasTexture(int index) const
         return nullptr;
     return m_atlases[index].texture;
 }
+
+} // namespace ui::textview

--- a/lib/TextView/lib/FontLoader.h
+++ b/lib/TextView/lib/FontLoader.h
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <QRawFont>
+#include <QFont>
 #include <QHash>
 #include <QReadWriteLock>
 #include <QtGui/6.9.1/QtGui/rhi/qrhi.h>
 #include <private/qdistancefield_p.h>
+
+namespace ui::textview {
 
 class FontLoader
 {
@@ -19,6 +22,7 @@ public:
 
     QString fileName() const;
     bool loadFont(const QString &fileName);
+    bool setFont(const QFont &font);
     bool isValid() const;
 
     qreal pixelSize() const;
@@ -54,3 +58,5 @@ private:
     QSize m_cellSize;
     int m_cellsPerRow = 1;
 };
+
+} // namespace ui::textview

--- a/lib/TextView/lib/TextAttributes.cpp
+++ b/lib/TextView/lib/TextAttributes.cpp
@@ -2,6 +2,7 @@
 #include "qglobal.h"
 #include <QHash>
 
+namespace ui::textview {
 using TextAttribteStorage = QHash<size_t, const TextAttributes::Data *>;
 Q_GLOBAL_STATIC(TextAttribteStorage, textAttributesStore)
 
@@ -50,3 +51,5 @@ const TextAttributes::Data *TextAttributes::get(const Data &d)
     textAttributesStore->insert(h, ptr);
     return ptr;
 }
+
+} // namespace ui::textview

--- a/lib/TextView/lib/TextAttributes.h
+++ b/lib/TextView/lib/TextAttributes.h
@@ -2,6 +2,8 @@
 
 #include <QColor>
 
+namespace ui::textview {
+
 class FontLoader;
 
 class TextAttributes
@@ -29,3 +31,5 @@ private:
     const Data *m_data = nullptr;
     static const Data *get(const Data &data);
 };
+
+} // namespace ui::textview

--- a/lib/TextView/lib/TextFramebuffer.cpp
+++ b/lib/TextView/lib/TextFramebuffer.cpp
@@ -2,6 +2,8 @@
 
 #include <algorithm>
 
+namespace ui::textview {
+
 TextBlock::TextBlock(int position)
     : m_position(position)
 {
@@ -187,4 +189,6 @@ QVector<TextLine> &TextFramebuffer::lines()
 {
     return m_lines;
 }
+
+} // namespace ui::textview
 

--- a/lib/TextView/lib/TextFramebuffer.h
+++ b/lib/TextView/lib/TextFramebuffer.h
@@ -9,6 +9,8 @@
 
 #include "TextAttributes.h"
 
+namespace ui::textview {
+
 struct TextElement
 {
     QChar character;
@@ -80,3 +82,4 @@ private:
     QVector<TextLine> m_lines;
 };
 
+} // namespace ui::textview

--- a/lib/TextView/lib/TextRenderer.cpp
+++ b/lib/TextView/lib/TextRenderer.cpp
@@ -4,6 +4,8 @@
 #include <QHash>
 #include <cstddef>
 
+namespace ui::textview {
+
 void TextRenderer::initialize(QRhi *rhi, QRhiRenderTarget *rt, QRhiCommandBuffer *cb)
 {
     m_rhi = rhi;
@@ -184,3 +186,5 @@ QSizeF TextRenderer::pixelSize() const
 {
     return QSizeF(m_viewWidth * m_charWidth, m_viewHeight * m_charHeight);
 }
+
+} // namespace ui::textview

--- a/lib/TextView/lib/TextRenderer.h
+++ b/lib/TextView/lib/TextRenderer.h
@@ -8,6 +8,8 @@
 #include "TextFramebuffer.h"
 #include "FontLoader.h"
 
+namespace ui::textview {
+
 class TextRenderer
 {
 public:
@@ -51,3 +53,5 @@ private:
     QRhiShaderResourceBindings *m_srb = nullptr;
     QRhiSampler *m_sampler = nullptr;
 };
+
+} // namespace ui::textview

--- a/lib/TextView/plugin/DFGlyph.cpp
+++ b/lib/TextView/plugin/DFGlyph.cpp
@@ -3,6 +3,7 @@
 #include <QDebug>
 #include <QPainterPath>
 
+namespace ui::textview::qml {
 DFGlyph::DFGlyph(QQuickItem *parent)
     : QQuickPaintedItem(parent)
 {
@@ -79,3 +80,5 @@ void DFGlyph::setDirty()
     updateDF();
     update();
 }
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/DFGlyph.h
+++ b/lib/TextView/plugin/DFGlyph.h
@@ -6,6 +6,8 @@
 
 Q_MOC_INCLUDE("FontLoaderObject.h")
 
+namespace ui::textview::qml {
+
 class FontLoaderObject;
 
 class DFGlyph : public QQuickPaintedItem
@@ -39,3 +41,5 @@ private:
     QDistanceField m_df;
     bool m_dirty = false;
 };
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/FontLoaderObject.cpp
+++ b/lib/TextView/plugin/FontLoaderObject.cpp
@@ -1,5 +1,7 @@
 #include "FontLoaderObject.h"
 
+namespace ui::textview::qml {
+
 FontLoaderObject::FontLoaderObject(QObject *parent)
     : QObject(parent)
 {
@@ -55,3 +57,5 @@ FontLoader *FontLoaderObject::loader()
 {
     return &m_loader;
 }
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/FontLoaderObject.h
+++ b/lib/TextView/plugin/FontLoaderObject.h
@@ -4,6 +4,8 @@
 #include <QtQml/qqml.h>
 #include "FontLoader.h"
 
+namespace ui::textview::qml {
+
 class FontLoaderObject : public QObject
 {
     Q_OBJECT
@@ -35,5 +37,7 @@ signals:
     void familyNameChanged();
 
 private:
-    FontLoader m_loader;
+    ui::textview::FontLoader m_loader;
 };
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/QmlTextAttributes.cpp
+++ b/lib/TextView/plugin/QmlTextAttributes.cpp
@@ -1,0 +1,33 @@
+#include "QmlTextAttributes.h"
+
+namespace ui::textview::qml {
+
+TextAttributes::TextAttributes() = default;
+
+QColor TextAttributes::background() const { return data().background; }
+void TextAttributes::setBackground(const QColor &c) {
+    *static_cast<ui::textview::TextAttributes*>(this) = ui::textview::TextAttributes(c, color(), outlineColor(), outlineWidth(), m_fontLoader ? m_fontLoader->loader() : nullptr);
+}
+
+QColor TextAttributes::color() const { return data().color; }
+void TextAttributes::setColor(const QColor &c) {
+    *static_cast<ui::textview::TextAttributes*>(this) = ui::textview::TextAttributes(background(), c, outlineColor(), outlineWidth(), m_fontLoader ? m_fontLoader->loader() : nullptr);
+}
+
+QColor TextAttributes::outlineColor() const { return data().outlineColor; }
+void TextAttributes::setOutlineColor(const QColor &c) {
+    *static_cast<ui::textview::TextAttributes*>(this) = ui::textview::TextAttributes(background(), color(), c, outlineWidth(), m_fontLoader ? m_fontLoader->loader() : nullptr);
+}
+
+float TextAttributes::outlineWidth() const { return data().outlineWidth; }
+void TextAttributes::setOutlineWidth(float w) {
+    *static_cast<ui::textview::TextAttributes*>(this) = ui::textview::TextAttributes(background(), color(), outlineColor(), w, m_fontLoader ? m_fontLoader->loader() : nullptr);
+}
+
+FontLoaderObject* TextAttributes::fontLoader() const { return m_fontLoader; }
+void TextAttributes::setFontLoader(FontLoaderObject *fl) {
+    m_fontLoader = fl;
+    *static_cast<ui::textview::TextAttributes*>(this) = ui::textview::TextAttributes(background(), color(), outlineColor(), outlineWidth(), m_fontLoader ? m_fontLoader->loader() : nullptr);
+}
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/QmlTextAttributes.h
+++ b/lib/TextView/plugin/QmlTextAttributes.h
@@ -1,0 +1,42 @@
+#pragma once
+#include <QColor>
+#include <QtQml/qqml.h>
+#include "TextAttributes.h"
+#include "FontLoaderObject.h"
+
+namespace ui::textview::qml {
+
+class TextAttributes : public ui::textview::TextAttributes
+{
+    Q_GADGET
+    QML_VALUE_TYPE(textAttributes)
+    QML_CONSTRUCTIBLE_VALUE
+    Q_PROPERTY(QColor background READ background WRITE setBackground)
+    Q_PROPERTY(QColor color READ color WRITE setColor)
+    Q_PROPERTY(QColor outlineColor READ outlineColor WRITE setOutlineColor)
+    Q_PROPERTY(float outlineWidth READ outlineWidth WRITE setOutlineWidth)
+    Q_PROPERTY(FontLoaderObject* fontLoader READ fontLoader WRITE setFontLoader)
+
+public:
+    TextAttributes();
+
+    QColor background() const;
+    void setBackground(const QColor &c);
+
+    QColor color() const;
+    void setColor(const QColor &c);
+
+    QColor outlineColor() const;
+    void setOutlineColor(const QColor &c);
+
+    float outlineWidth() const;
+    void setOutlineWidth(float w);
+
+    FontLoaderObject* fontLoader() const;
+    void setFontLoader(FontLoaderObject *fl);
+
+private:
+    FontLoaderObject *m_fontLoader = nullptr;
+};
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/QuickTextViewRenderer.cpp
+++ b/lib/TextView/plugin/QuickTextViewRenderer.cpp
@@ -3,6 +3,8 @@
 #include "FontLoaderObject.h"
 #include "TextFramebufferObject.h"
 
+namespace ui::textview::qml {
+
 void QuickTextViewRenderer::initialize(QRhiCommandBuffer *cb)
 {
     m_renderer.initialize(rhi(), renderTarget(), cb);
@@ -12,20 +14,31 @@ void QuickTextViewRenderer::synchronize(QQuickRhiItem *item)
 {
     m_view = static_cast<TextView *>(item);
     if (m_view && m_view->framebuffer()) {
-        QRect region(m_view->posX(), m_view->posY(), m_view->width(), m_view->height());
+        QRect region(m_view->posX(), m_view->posY(), m_view->renderWidth(), m_view->renderHeight());
         m_cells = m_view->framebuffer()->buffer()->collect(region);
     } else {
         m_cells.clear();
     }
+    ui::textview::FontLoader *fl = nullptr;
+    if (m_view) {
+        if (m_view->fontLoader())
+            fl = m_view->fontLoader()->loader();
+        else if (m_view->framebuffer())
+            fl = m_view->framebuffer()->loader();
+    }
     m_renderer.prepare(m_cells,
-                       m_view && m_view->fontLoader() ? m_view->fontLoader()->loader() : nullptr,
+                       fl,
                        m_view ? m_view->posX() : 0, m_view ? m_view->posY() : 0,
-                       m_view ? m_view->width() : 0, m_view ? m_view->height() : 0);
+                       m_view ? m_view->renderWidth() : 0, m_view ? m_view->renderHeight() : 0);
 }
 
 void QuickTextViewRenderer::render(QRhiCommandBuffer *cb)
 {
-    if (!m_view || !m_view->fontLoader() || m_cells.isEmpty())
+    if (!m_view || m_cells.isEmpty())
+        return;
+    if (!m_view->fontLoader() && !(m_view->framebuffer() && m_view->framebuffer()->loader()))
         return;
     m_renderer.render(cb);
 }
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/QuickTextViewRenderer.h
+++ b/lib/TextView/plugin/QuickTextViewRenderer.h
@@ -5,6 +5,8 @@
 #include "TextRenderer.h"
 #include "TextFramebuffer.h"
 
+namespace ui::textview::qml {
+
 class TextView;
 
 class QuickTextViewRenderer : public QQuickRhiItemRenderer
@@ -19,6 +21,8 @@ protected:
 
 private:
     TextView *m_view = nullptr;
-    QVector<RenderCell> m_cells;
-    TextRenderer m_renderer;
+    QVector<ui::textview::RenderCell> m_cells;
+    ui::textview::TextRenderer m_renderer;
 };
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/TextAttributesSingleton.h
+++ b/lib/TextView/plugin/TextAttributesSingleton.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <QObject>
+#include <QtQml/qqml.h>
+#include "QmlTextAttributes.h"
+
+namespace ui::textview::qml {
+
+class TextAttributesSingleton : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_SINGLETON
+public:
+    Q_INVOKABLE TextAttributes create() const { return TextAttributes(); }
+};
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/TextFramebufferObject.cpp
+++ b/lib/TextView/plugin/TextFramebufferObject.cpp
@@ -1,8 +1,12 @@
 #include "TextFramebufferObject.h"
+#include "QmlTextAttributes.h"
+
+namespace ui::textview::qml {
 
 TextFramebufferObject::TextFramebufferObject(QObject *parent)
     : QObject(parent)
 {
+    m_loader.setFont(m_font);
 }
 
 TextFramebuffer *TextFramebufferObject::buffer()
@@ -13,6 +17,25 @@ TextFramebuffer *TextFramebufferObject::buffer()
 const TextFramebuffer *TextFramebufferObject::buffer() const
 {
     return &m_buffer;
+}
+
+ui::textview::FontLoader *TextFramebufferObject::loader()
+{
+    return &m_loader;
+}
+
+QFont TextFramebufferObject::font() const
+{
+    return m_font;
+}
+
+void TextFramebufferObject::setFont(const QFont &font)
+{
+    if (m_font == font)
+        return;
+    m_font = font;
+    m_loader.setFont(m_font);
+    emit fontChanged();
 }
 
 void TextFramebufferObject::putText(int row, int column, const QString &text, const TextAttributes &attr)
@@ -34,3 +57,5 @@ void TextFramebufferObject::fill(const QRect &rect, QChar ch, const TextAttribut
 {
     m_buffer.fill(rect, ch, attr);
 }
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/TextFramebufferObject.h
+++ b/lib/TextView/plugin/TextFramebufferObject.h
@@ -3,6 +3,11 @@
 #include <QObject>
 #include <QtQml/qqml.h>
 #include "TextFramebuffer.h"
+#include "FontLoader.h"
+#include "QmlTextAttributes.h"
+#include <QFont>
+
+namespace ui::textview::qml {
 
 class TextFramebufferObject : public QObject
 {
@@ -13,12 +18,22 @@ public:
 
     TextFramebuffer *buffer();
     const TextFramebuffer *buffer() const;
+    ui::textview::FontLoader *loader();
+
+    Q_PROPERTY(QFont font READ font WRITE setFont NOTIFY fontChanged)
 
     Q_INVOKABLE void putText(int row, int column, const QString &text, const TextAttributes &attr);
     Q_INVOKABLE void writeLn(const QString &text, const TextAttributes &attr);
     Q_INVOKABLE void clear(const QRect &rect);
     Q_INVOKABLE void fill(const QRect &rect, QChar ch, const TextAttributes &attr);
 
+signals:
+    void fontChanged();
+
 private:
     TextFramebuffer m_buffer;
+    QFont m_font;
+    ui::textview::FontLoader m_loader;
 };
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/TextView.cpp
+++ b/lib/TextView/plugin/TextView.cpp
@@ -3,6 +3,7 @@
 #include <QRawFont>
 #include <QDebug>
 
+namespace ui::textview::qml {
 TextView::TextView(QQuickItem *parent)
     : QQuickRhiItem(parent)
 {
@@ -54,33 +55,33 @@ void TextView::setFramebuffer(TextFramebufferObject *fb)
     update();
 }
 
-int TextView::width() const
+int TextView::renderWidth() const
 {
-    return m_width;
+    return m_renderWidth;
 }
 
-void TextView::setWidth(int w)
+void TextView::setRenderWidth(int w)
 {
-    if (m_width == w)
+    if (m_renderWidth == w)
         return;
-    m_width = w;
+    m_renderWidth = w;
     updateImplicitSize();
-    emit widthChanged();
+    emit renderWidthChanged();
     update();
 }
 
-int TextView::height() const
+int TextView::renderHeight() const
 {
-    return m_height;
+    return m_renderHeight;
 }
 
-void TextView::setHeight(int h)
+void TextView::setRenderHeight(int h)
 {
-    if (m_height == h)
+    if (m_renderHeight == h)
         return;
-    m_height = h;
+    m_renderHeight = h;
     updateImplicitSize();
-    emit heightChanged();
+    emit renderHeightChanged();
     update();
 }
 
@@ -124,6 +125,8 @@ void TextView::updateImplicitSize()
     const QRawFont &f = m_fontLoader->font();
     const qreal charWidth = f.averageCharWidth();
     const qreal charHeight = f.ascent() + f.descent();
-    setImplicitWidth(m_width * charWidth);
-    setImplicitHeight(m_height * charHeight);
+    setImplicitWidth(m_renderWidth * charWidth);
+    setImplicitHeight(m_renderHeight * charHeight);
 }
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/TextView.h
+++ b/lib/TextView/plugin/TextView.h
@@ -6,13 +6,15 @@
 #include "TextFramebufferObject.h"
 #include "FontLoaderObject.h"
 
+namespace ui::textview::qml {
+
 class TextView : public QQuickRhiItem
 {
     Q_OBJECT
     QML_ELEMENT
     Q_PROPERTY(TextFramebufferObject* framebuffer READ framebuffer WRITE setFramebuffer NOTIFY framebufferChanged)
-    Q_PROPERTY(int width READ width WRITE setWidth NOTIFY widthChanged)
-    Q_PROPERTY(int height READ height WRITE setHeight NOTIFY heightChanged)
+    Q_PROPERTY(int renderWidth READ renderWidth WRITE setRenderWidth NOTIFY renderWidthChanged)
+    Q_PROPERTY(int renderHeight READ renderHeight WRITE setRenderHeight NOTIFY renderHeightChanged)
     Q_PROPERTY(int posX READ posX WRITE setPosX NOTIFY posXChanged)
     Q_PROPERTY(int posY READ posY WRITE setPosY NOTIFY posYChanged)
     Q_PROPERTY(qreal fontSize READ fontSize WRITE setFontSize NOTIFY fontSizeChanged)
@@ -29,11 +31,11 @@ public:
     qreal fontSize() const;
     void setFontSize(qreal size);
 
-    int width() const;
-    void setWidth(int w);
+    int renderWidth() const;
+    void setRenderWidth(int w);
 
-    int height() const;
-    void setHeight(int h);
+    int renderHeight() const;
+    void setRenderHeight(int h);
 
     int posX() const;
     void setPosX(int x);
@@ -44,8 +46,8 @@ public:
 
 signals:
     void framebufferChanged();
-    void widthChanged();
-    void heightChanged();
+    void renderWidthChanged();
+    void renderHeightChanged();
     void posXChanged();
     void posYChanged();
     void fontLoaderChanged();
@@ -56,8 +58,8 @@ protected:
 
 private:
     TextFramebufferObject *m_framebuffer = nullptr;
-    int m_width = 0;
-    int m_height = 0;
+    int m_renderWidth = 0;
+    int m_renderHeight = 0;
     int m_posX = 0;
     int m_posY = 0;
     FontLoaderObject *m_fontLoader = nullptr;
@@ -65,3 +67,5 @@ private:
 
     void updateImplicitSize();
 };
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/plugin.cpp
+++ b/lib/TextView/plugin/plugin.cpp
@@ -4,6 +4,10 @@
 #include "DFGlyph.h"
 #include "FontLoaderObject.h"
 #include "TextFramebufferObject.h"
+#include "QmlTextAttributes.h"
+#include "TextAttributesSingleton.h"
+
+namespace ui::textview::qml {
 
 void UiEditorsPlugin::registerTypes(const char *uri)
 {
@@ -12,4 +16,8 @@ void UiEditorsPlugin::registerTypes(const char *uri)
     qmlRegisterType<DFGlyph>(uri, 1, 0, "DFGlyph");
     qmlRegisterType<FontLoaderObject>(uri, 1, 0, "FontLoader");
     qmlRegisterType<TextFramebufferObject>(uri, 1, 0, "TextFramebuffer");
+    qmlRegisterUncreatableType<TextAttributes>(uri, 1, 0, "TextAttributes", QStringLiteral("Use TextAttributes.create()"));
+    qmlRegisterSingletonType<TextAttributesSingleton>(uri, 1, 0, "TextAttributes", [](QQmlEngine *, QJSEngine *) -> QObject* { return new TextAttributesSingleton; });
 }
+
+} // namespace ui::textview::qml

--- a/lib/TextView/plugin/plugin.h
+++ b/lib/TextView/plugin/plugin.h
@@ -2,6 +2,8 @@
 
 #include <QQmlExtensionPlugin>
 
+namespace ui::textview::qml {
+
 class UiEditorsPlugin : public QQmlExtensionPlugin
 {
     Q_OBJECT
@@ -10,3 +12,5 @@ class UiEditorsPlugin : public QQmlExtensionPlugin
 public:
     void registerTypes(const char *uri) override;
 };
+
+} // namespace ui::textview::qml


### PR DESCRIPTION
## Summary
- add sample TextViewDemoApp using new TextView QML API
- namespace library code as `ui::textview` and plugin code as `ui::textview::qml`
- register QML `TextAttributes` gadget and factory
- expose render width/height properties on `TextView`
